### PR TITLE
FIX error no plano carbon e no slots

### DIFF
--- a/faq/premium.md
+++ b/faq/premium.md
@@ -9,11 +9,11 @@ description: >-
 
 ## 💎 Planos
 
-| Plano | Memória | CPU | Max. Bots | Preço \(R$\) | Moderadores | Git | Slot limitado | Timer |
+| Plano | Memória | CPU | Max. Bots | Preço \(R$\) | Moderadores | Git | Slot ilimitado | Timer |
 | :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
 | ![](../.gitbook/assets/free.png) Free | **100mb** | 0.25 | 1 | - | 0 | Não  | Não | Sim |
 | ![](../.gitbook/assets/booster.png) Booster | **100mb** | 0.25 | 1 | - | 0 | Não | Sim | Não |
-| ![](../.gitbook/assets/carbon.png) Carbon | **128mb** | 0.25 | 1 | 1,99 | 0 | Não | Sim | Não |
+| ![](../.gitbook/assets/carbon.png) Carbon | **128mb** | 0.25 | 1 | 1,99 | 0 | Sim | Sim | Não |
 | ![](../.gitbook/assets/gold.png) Gold | **512mb** | 0.5 | 5 | 5,99 | 1 | Sim | Sim | Não |
 | ![](../.gitbook/assets/platinum.png) Platinum | **1Gb** | 1 | 10 | 10,99 | 2 | Sim | Sim | Não |
 | ![](../.gitbook/assets/diamond.png) Diamond | **2Gb** | 2 | 20 | 24,00 | 3 | Sim | Sim | Não |


### PR DESCRIPTION
O plano carbon tinha 1 erro no git 
- está a dizer que o Carbon não tem permissão para usar o git mas na verdade tem

- E coluna do slot faltava 1 `i` para dizer `ilimitado` em vez de `limitado` dando a dizer o plano free não tem limites para bots e os planos sim